### PR TITLE
No longer use stdin to talk to openssl

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,12 +38,17 @@ csrgen(domain, {
 CSR will perform the following shell command:
 
 ```
-$ openssl req -nodes -newkey rsa:2048 -keyout ./exampledomain.com.key -out ./exampledomain.com.csr
+$ openssl req -nodes -newkey rsa:2048 -keyout ./exampledomain.com.key -out ./exampledomain.com.csr -subj '/C=US/ST=California/L=San Fransisco/O=FooBar/OU=Operations/CN=foobar.com/emailAddress=info@foobar.biz'
 Generating a 2048 bit RSA private key
 ...................................................................+++
 ................................................................................................................................+++
 writing new private key to './exampledomain.com.key'
 -----
+```
+
+__And you're done!__ Adding the -subj (above) switch allows us to skip the following familiar process!
+
+```
 You are about to be asked to enter information that will be incorporated
 into your certificate request.
 What you are about to enter is what is called a Distinguished Name or a DN.
@@ -77,7 +82,6 @@ An optional company name []:
 * division, default: "Operations"
 * email, typically required, empty by default
 * password, default empty
-* optionalCompany, second company name, defaults empty
 * keyName, the filename of the private key to export. Defaults to `domain+'.key'`
 * csrName, the filename of the csr to export. Defaults to `domain+'.csr'`
 

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
   "main": "src/csr-gen",
   "description": "Generates OpenSSL Certificate Signing Requests",
   "dependencies": {
-    "underscore": "1.4.x"
+    "underscore": "1.4.x",
+    "underscore.string": "2.3.x"
   },
   "licenses": [
     {

--- a/test.js
+++ b/test.js
@@ -4,9 +4,11 @@ console.log('Generating CSR');
 
 csrgen('foobar.com', {
   destroy: true,
+  read: true,
   outputDir: __dirname,
-	company: 'FooBar',
-	email: 'info@foobar.biz'
+  company: 'FooBar',
+  email: 'info@foobar.biz',
+  password: 'asdf'
 }, function(err, a){
 
   if(err) return console.log('Something went wrong!');


### PR DESCRIPTION
Now passes all options as parameters to openssl.

Be aware that passwords are passed by writing to a temporary file
and immediately deleting it after openssl exits.

I have also removed the optionalCompany option.
